### PR TITLE
Support github package registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,6 @@
   "types": "types/index.d.ts",
   "repository": "https://github.com/Tradeshift/react-components",
   "homepage": "https://tradeshift.github.io/react-components",
-  "publishConfig": {
-    "registry": "https://npm-upload.tradeshift.net/repository/npm-internal/"
-  },
   "engines": {
     "node": ">=8.12.0",
     "npm": ">=6.4.0"


### PR DESCRIPTION
Change to preserve checksum between registries. Will allow smooth transition for subsequent releases.

See migration doc for context:
https://docs.google.com/document/d/19U-_Gt1L1IqVCaUG9YCVHXiMid9TsqEKi-RzXy4pfJQ/edit#

Migration worksheet:
https://docs.google.com/spreadsheets/d/1CcaWqJB_3mxlCG87HwsrNq4Tqye5hMw2UyIgf1LsIEU/edit#gid=0